### PR TITLE
Fix life stone count

### DIFF
--- a/app/contract-boost-calculator/page.tsx
+++ b/app/contract-boost-calculator/page.tsx
@@ -78,8 +78,8 @@ export default function ContractBoostCalculator() {
       chalice: chaliceOptionValue ? chaliceOptionValue : prevState.chalice,
       gusset: gussetOptionValue ? gussetOptionValue : prevState.gusset,
       t2LifeStonesCount: t2LifeStonesCount ? t2LifeStonesCount : prevState.t2LifeStonesCount,
-      t3LifeStonesCount: t3LifeStonesCount ? t3LifeStonesCount : prevState.t2LifeStonesCount,
-      t4LifeStonesCount: t4LifeStonesCount ? t4LifeStonesCount : prevState.t2LifeStonesCount,
+      t3LifeStonesCount: t3LifeStonesCount ? t3LifeStonesCount : prevState.t3LifeStonesCount,
+      t4LifeStonesCount: t4LifeStonesCount ? t4LifeStonesCount : prevState.t4LifeStonesCount,
     }));
   }, [equippedArtifactsListForSelectedIGN]);
 


### PR DESCRIPTION
Symptom: life stone counts kept being reset to 0

Cause: All fields were being reset to the _T2_ life stone count in `prevState`, which was (likely) zero for the people who reported it :kek: